### PR TITLE
Add Jacoco coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This will compile all modules and execute the unit tests. The tests expect a `ph
 
 Before running the tests, update the `test.pay_lnaddress` entry in that file so it targets a Lightning address that you control.
 
+## Code coverage
+Running `mvn clean verify` generates a Jacoco coverage report. The aggregated HTML report is written to `target/site/jacoco-aggregate/index.html`.
+
 ## Usage example
 ```java
 Configuration cfg = new Configuration("phoenixd");

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,27 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>aggregate-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
## Summary
- generate Jacoco coverage reports
- document coverage instructions in README

## Testing
- `mvn -q verify` *(fails: Could not resolve dependencies for project phoenixd-model)*

------
https://chatgpt.com/codex/tasks/task_b_68868d30d82083318af3b693f1ee4f00