### PR TITLE
Refactor HttpResponse usage and add network call test

### DIFF
--- a/phoenixd-rest/pom.xml
+++ b/phoenixd-rest/pom.xml
@@ -29,10 +29,31 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -86,8 +86,9 @@ public abstract class AbstractOperation implements Operation {
         CompletableFuture<HttpResponse<String>> response = HttpClient.newBuilder()
                 .build()
                 .sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString());
-        this.responseBody = response.get().body();
-        var statusCode = response.get().statusCode();
+        HttpResponse<String> httpResp = response.get();
+        this.responseBody = httpResp.body();
+        var statusCode = httpResp.statusCode();
         if (statusCode < 200 || statusCode >= 300) {
             throw new IOException("Failed to create invoice: " + statusCode + " " + responseBody);
         }

--- a/phoenixd-rest/src/test/java/xyz/tcheeric/phoenixd/operation/AbstractOperationTest.java
+++ b/phoenixd-rest/src/test/java/xyz/tcheeric/phoenixd/operation/AbstractOperationTest.java
@@ -1,0 +1,34 @@
+package xyz.tcheeric.phoenixd.operation;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.phoenixd.operation.impl.GetOperation;
+
+import java.net.http.HttpRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractOperationTest {
+
+    @Test
+    void executeMakesSingleNetworkCall() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+        server.start();
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(server.url("/test").uri())
+                    .GET()
+                    .build();
+            GetOperation operation = new GetOperation(request);
+
+            operation.execute();
+
+            assertThat(server.getRequestCount()).isEqualTo(1);
+            assertThat(operation.getResponseBody()).isEqualTo("ok");
+        } finally {
+            server.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Avoid multiple `CompletableFuture#get` calls by caching the `HttpResponse` in `AbstractOperation.execute`.
- Add unit test verifying a single network call using `MockWebServer`.
- Include required test dependencies for mocking and assertions.

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a42bef008331a849240d0be10104