### PR TITLE
Handle invalid pay request input

### DIFF
--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/request/impl/rest/PayRequestFactory.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/request/impl/rest/PayRequestFactory.java
@@ -21,8 +21,7 @@ public class PayRequestFactory {
             param.setInvoice(request);
             return new PayBolt11InvoiceRequest(param);
         } else {
-            return null;
-            //throw new IllegalArgumentException("Invalid request format");
+            throw new IllegalArgumentException("Invalid request format");
         }
     }
 }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayRequestFactoryTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayRequestFactoryTest.java
@@ -1,0 +1,27 @@
+package xyz.tcheeric.phoenixd.request.impl.rest.test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import xyz.tcheeric.phoenixd.request.impl.rest.PayRequestFactory;
+import xyz.tcheeric.phoenixd.request.impl.rest.PayBolt11InvoiceRequest;
+import xyz.tcheeric.phoenixd.request.impl.rest.PayLightningAddressRequest;
+
+public class PayRequestFactoryTest {
+
+    @Test
+    public void testCreateLightningAddressRequest() {
+        assertTrue(PayRequestFactory.createPayRequest("alice@example.com") instanceof PayLightningAddressRequest);
+    }
+
+    @Test
+    public void testCreateBolt11InvoiceRequest() {
+        assertTrue(PayRequestFactory.createPayRequest("lnbc1u1pw0kx7pp5") instanceof PayBolt11InvoiceRequest);
+    }
+
+    @Test
+    public void testInvalidRequestThrows() {
+        assertThrows(IllegalArgumentException.class, () -> PayRequestFactory.createPayRequest("invalid"));
+    }
+}


### PR DESCRIPTION
## Summary
- Throw IllegalArgumentException when pay request string is neither a Lightning address nor a BOLT11 invoice
- Add unit tests for PayRequestFactory including invalid input case

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a430a78c8331ba33710a083ebde1