### PR TITLE
Replace path placeholders with param values

### DIFF
--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -133,7 +133,6 @@ public abstract class AbstractOperation implements Operation {
         return httpRequest.headers().firstValue(key).orElse(null);
     }
 
-    @SneakyThrows
     public String replacePathVariables(String path, Request.Param param) {
         if (param == null || param.getKind() != Request.Param.Kind.PATH) {
             return path;

--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -14,6 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
@@ -71,9 +72,13 @@ public abstract class AbstractOperation implements Operation {
 
         HttpRequest.BodyPublisher bodyPublisher = requestData == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(requestData);
 
-        String separator = param.getKind() == Request.Param.Kind.PATH ? "/" : "?";
+        String resolvedPath = replacePathVariables(path, param);
+        if (param.getKind() == Request.Param.Kind.QUERY) {
+            resolvedPath = resolvedPath + "?" + param;
+        }
+
         this.httpRequest = HttpRequest.newBuilder()
-                .uri(URI.create(baseUrl + replacePathVariables(path, param) + separator + param))
+                .uri(URI.create(baseUrl + resolvedPath))
                 .header("Authorization", "Basic " + encodedAuth)
                 .timeout(Duration.ofMillis(timeout))
                 .method(method, bodyPublisher)
@@ -128,7 +133,21 @@ public abstract class AbstractOperation implements Operation {
         return httpRequest.headers().firstValue(key).orElse(null);
     }
 
+    @SneakyThrows
     public String replacePathVariables(String path, Request.Param param) {
+        if (param == null || param.getKind() != Request.Param.Kind.PATH) {
+            return path;
+        }
+
+        Field[] fields = param.getClass().getDeclaredFields();
+        for (Field field : fields) {
+            field.setAccessible(true);
+            Object value = field.get(param);
+            if (value != null) {
+                String placeholder = "{" + field.getName() + "}";
+                path = path.replace(placeholder, value.toString());
+            }
+        }
         return path;
     }
 }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/PathVariableReplacementTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/PathVariableReplacementTest.java
@@ -1,0 +1,32 @@
+package xyz.tcheeric.phoenixd.operation;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.phoenixd.common.rest.Request;
+import xyz.tcheeric.phoenixd.operation.impl.GetOperation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PathVariableReplacementTest {
+
+    static class MultiPathParam implements Request.Param {
+        private final String id;
+        private final String subId;
+
+        MultiPathParam(String id, String subId) {
+            this.id = id;
+            this.subId = subId;
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+    }
+
+    @Test
+    public void replacesMultipleVariables() {
+        MultiPathParam param = new MultiPathParam("123", "456");
+        GetOperation operation = new GetOperation("/path/{id}/child/{subId}", param);
+        assertEquals("http://localhost:9740/path/123/child/456", operation.getHttpRequest().uri().toString());
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve path variables using Request.Param values for PATH parameters
- Add tests ensuring multiple placeholders resolve correctly

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a44dad188331980ab99d4c33576a