### PR TITLE
Preserve original method when adding headers

### DIFF
--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -104,6 +104,10 @@ public abstract class AbstractOperation implements Operation {
                 ));
         newHeadersMap.put(key, List.of(value));
 
+        String method = httpRequest.method();
+        HttpRequest.BodyPublisher bodyPublisher = httpRequest.bodyPublisher()
+                .orElse(HttpRequest.BodyPublishers.noBody());
+
         HttpRequest newHttpRequest = HttpRequest.newBuilder()
                 .uri(httpRequest.uri())
                 .timeout(httpRequest.timeout().orElse(null))
@@ -111,12 +115,12 @@ public abstract class AbstractOperation implements Operation {
                         .flatMap(e -> e.getValue().stream().map(v -> Map.entry(e.getKey(), v)))
                         .flatMap(e -> Stream.of(e.getKey(), e.getValue()))
                         .toArray(String[]::new))
-                .POST(httpRequest.bodyPublisher().orElse(HttpRequest.BodyPublishers.noBody()))
+                .method(method, bodyPublisher)
                 .build();
 
         this.setHttpRequest(newHttpRequest);
 
-        return new PostOperation(newHttpRequest);
+        return this;
     }
 
     @Override

--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/impl/PatchOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/impl/PatchOperation.java
@@ -26,7 +26,7 @@ public class PatchOperation extends AbstractOperation {
 
     @Override
     public Operation addHeader(String key, String value) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        return super.addHeader(key, value);
     }
 
 }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/AddHeaderOperationTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/AddHeaderOperationTest.java
@@ -1,0 +1,29 @@
+package xyz.tcheeric.phoenixd.operation.impl;
+
+import org.junit.jupiter.api.Test;
+import xyz.tcheeric.phoenixd.common.rest.Operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddHeaderOperationTest {
+
+    @Test
+    void addHeaderDoesNotChangeMethodForGetOperation() {
+        GetOperation operation = new GetOperation("/test");
+        Operation result = operation.addHeader("X-Test", "value");
+
+        assertThat(result).isInstanceOf(GetOperation.class);
+        assertThat(operation.getHttpRequest().method()).isEqualTo("GET");
+        assertThat(operation.getHeader("X-Test")).isEqualTo("value");
+    }
+
+    @Test
+    void addHeaderDoesNotChangeMethodForPatchOperation() {
+        PatchOperation operation = new PatchOperation("/test");
+        Operation result = operation.addHeader("X-Test", "value");
+
+        assertThat(result).isInstanceOf(PatchOperation.class);
+        assertThat(operation.getHttpRequest().method()).isEqualTo("PATCH");
+        assertThat(operation.getHeader("X-Test")).isEqualTo("value");
+    }
+}


### PR DESCRIPTION
## Summary
- keep original HTTP method when adding headers
- delegate PatchOperation header addition to base implementation
- test that adding headers does not alter HTTP method

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_6896a458eeb08331b92d594b8cb826b9