### PR TITLE
test: add delete and patch operation tests

### DIFF
--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/test/DeleteOperationTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/test/DeleteOperationTest.java
@@ -1,0 +1,50 @@
+package xyz.tcheeric.phoenixd.operation.impl.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import xyz.tcheeric.phoenixd.common.rest.Request;
+import xyz.tcheeric.phoenixd.common.rest.Response;
+import xyz.tcheeric.phoenixd.operation.impl.DeleteOperation;
+import xyz.tcheeric.phoenixd.request.impl.DeleteRequest;
+import xyz.tcheeric.phoenixd.test.LocalTestServerExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(LocalTestServerExtension.class)
+public class DeleteOperationTest {
+
+    static class DeleteResponse implements Response {
+        private String status;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+    }
+
+    static class TestDeleteRequest extends DeleteRequest<Request.Param, DeleteResponse> {
+        public TestDeleteRequest() {
+            super("/delete");
+        }
+    }
+
+    @Test
+    public void testDeleteOperation() {
+        TestDeleteRequest request = new TestDeleteRequest();
+
+        assertEquals("/delete", request.getPath());
+        assertEquals(DeleteOperation.class, request.getOperation().getClass());
+        assertEquals("DELETE", ((DeleteOperation) request.getOperation()).getHttpRequest().method());
+
+        assertNotNull(request.getOperation().getHeader("Authorization"));
+        request.removeHeader("Authorization");
+        assertNull(request.getOperation().getHeader("Authorization"));
+        assertThrows(UnsupportedOperationException.class, () -> request.getOperation().addHeader("x", "y"));
+
+        DeleteResponse response = request.getResponse();
+        assertEquals("deleted", response.getStatus());
+    }
+}

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/test/PatchOperationTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/operation/impl/test/PatchOperationTest.java
@@ -1,0 +1,49 @@
+package xyz.tcheeric.phoenixd.operation.impl.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import xyz.tcheeric.phoenixd.common.rest.Request;
+import xyz.tcheeric.phoenixd.common.rest.Response;
+import xyz.tcheeric.phoenixd.operation.impl.PatchOperation;
+import xyz.tcheeric.phoenixd.request.impl.PatchRequest;
+import xyz.tcheeric.phoenixd.test.LocalTestServerExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(LocalTestServerExtension.class)
+public class PatchOperationTest {
+
+    static class PatchResponse implements Response {
+        private String status;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+    }
+
+    static class TestPatchRequest extends PatchRequest<Request.Param, PatchResponse> {
+        public TestPatchRequest() {
+            super("/patch");
+        }
+    }
+
+    @Test
+    public void testPatchOperation() {
+        TestPatchRequest request = new TestPatchRequest();
+
+        assertEquals("/patch", request.getPath());
+        assertEquals(PatchOperation.class, request.getOperation().getClass());
+        assertEquals("PATCH", ((PatchOperation) request.getOperation()).getHttpRequest().method());
+
+        assertNotNull(request.getOperation().getHeader("Authorization"));
+        assertThrows(UnsupportedOperationException.class, () -> request.getOperation().addHeader("x", "y"));
+        assertThrows(UnsupportedOperationException.class, () -> request.getOperation().removeHeader("Authorization"));
+
+        PatchResponse response = request.getResponse();
+        assertEquals("patched", response.getStatus());
+    }
+}

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/LocalTestServer.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/LocalTestServer.java
@@ -18,6 +18,8 @@ public class LocalTestServer {
         server.createContext("/paylnaddress", this::handlePayLightningAddress);
         server.createContext("/createinvoice", this::handleCreateInvoice);
         server.createContext("/decodeinvoice", this::handleDecodeInvoice);
+        server.createContext("/delete", this::handleDelete);
+        server.createContext("/patch", this::handlePatch);
         server.setExecutor(null);
         server.start();
     }
@@ -43,6 +45,14 @@ public class LocalTestServer {
 
     private void handleDecodeInvoice(HttpExchange exchange) throws IOException {
         writeJson(exchange, "{\"amount\":1000,\"description\":\"1 Blockaccino\"}");
+    }
+
+    private void handleDelete(HttpExchange exchange) throws IOException {
+        writeJson(exchange, "{\"status\":\"deleted\"}");
+    }
+
+    private void handlePatch(HttpExchange exchange) throws IOException {
+        writeJson(exchange, "{\"status\":\"patched\"}");
     }
 
     private void writeJson(HttpExchange exchange, String json) throws IOException {


### PR DESCRIPTION
## Summary
- test delete operation behavior including header removal and response parsing
- test patch operation with unsupported header modification behavior
- support /delete and /patch endpoints in LocalTestServer

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a4621af48331a6a0505393196ede