### PR TITLE
Throw exception by default for Request#getResponse

### DIFF
--- a/phoenixd-base/pom.xml
+++ b/phoenixd-base/pom.xml
@@ -29,5 +29,15 @@
             <artifactId>commons-configuration2</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/phoenixd-base/src/main/java/xyz/tcheeric/phoenixd/common/rest/Request.java
+++ b/phoenixd-base/src/main/java/xyz/tcheeric/phoenixd/common/rest/Request.java
@@ -3,7 +3,7 @@ package xyz.tcheeric.phoenixd.common.rest;
 public interface Request<T extends Request.Param, U extends Response> {
 
     default U getResponse() {
-        return null;
+        throw new UnsupportedOperationException("Implement getResponse in Request implementations");
     }
 
     interface Param {

--- a/phoenixd-base/src/test/java/xyz/tcheeric/phoenixd/common/rest/RequestTest.java
+++ b/phoenixd-base/src/test/java/xyz/tcheeric/phoenixd/common/rest/RequestTest.java
@@ -1,0 +1,14 @@
+package xyz.tcheeric.phoenixd.common.rest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequestTest {
+
+    @Test
+    void defaultGetResponseThrowsUnsupportedOperationException() {
+        Request<Request.Param, Response> request = new Request<Request.Param, Response>() {};
+        assertThrows(UnsupportedOperationException.class, request::getResponse);
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure Request implementations override getResponse by defaulting to UnsupportedOperationException
- Add unit test validating the default getResponse behavior and test dependencies

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a46bd9d48331b6703286121233f4