### PR TITLE
feat: add Dockerfile for phoenixd-rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ mvn -q verify
 
 This command executes unit and integration tests for all modules.
 
+## Docker
+Build and run the `phoenixd-rest` module in a container after packaging the project:
+
+```bash
+mvn -q -pl phoenixd-rest -am package
+docker build -t phoenixd-rest ./phoenixd-rest
+docker run -p 9740:9740 phoenixd-rest
+```
+
+The image uses Java 21 and exposes port `9740`.
+
 ## Code coverage
 Running `mvn clean verify` generates a Jacoco coverage report. The aggregated HTML report is written to `target/site/jacoco-aggregate/index.html`.
 

--- a/phoenixd-rest/Dockerfile
+++ b/phoenixd-rest/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jre
 
 WORKDIR /app
-COPY target/phoenixd-rest-1.0-SNAPSHOT.jar /app/phoenixd-rest.jar
+COPY target/phoenixd-rest-*.jar /app/phoenixd-rest.jar
 
 EXPOSE 9740
 

--- a/phoenixd-rest/Dockerfile
+++ b/phoenixd-rest/Dockerfile
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+COPY target/phoenixd-rest-1.0-SNAPSHOT.jar /app/phoenixd-rest.jar
+
+EXPOSE 9740
+
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar phoenixd-rest.jar"]

--- a/phoenixd-rest/Dockerfile
+++ b/phoenixd-rest/Dockerfile
@@ -7,4 +7,4 @@ EXPOSE 9740
 
 ENV JAVA_OPTS="-Xms256m -Xmx512m"
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar phoenixd-rest.jar"]
+ENTRYPOINT ["java", "-Xms256m", "-Xmx512m", "-jar", "phoenixd-rest.jar"]


### PR DESCRIPTION
## Summary
- containerize phoenixd-rest with a Dockerfile using eclipse-temurin:21-jre and default JVM memory options
- document Docker image build and run instructions

## Testing
- `mvn -q verify`
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896a3ec5e58833181a1d647f1423465