### PR TITLE
Add CI workflow for Maven build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jacoco-aggregate
           path: target/site/**/jacoco-aggregate/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jacoco-aggregate
-          path: target/site/jacoco-aggregate/
+          path: target/site/**/jacoco-aggregate/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-aggregate
-          path: target/site/**/jacoco-aggregate/
+          path: target/site/jacoco-aggregate/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Verify
+        run: mvn -q verify
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-aggregate
+          path: target/site/jacoco-aggregate/


### PR DESCRIPTION
## Summary
- add CI workflow to run Maven verification with JDK 21 and cache dependencies
- upload aggregated JaCoCo coverage report as an artifact

## Testing
- `mvn -q verify`
```
Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
```


------
https://chatgpt.com/codex/tasks/task_b_6896a3e1bea0833184013d502a9b0a44