### PR TITLE
Use environment variables for phoenixd credentials and expose in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PHOENIXD_USERNAME: ${{ secrets.PHOENIXD_USERNAME }}
+      PHOENIXD_PASSWORD: ${{ secrets.PHOENIXD_PASSWORD }}
+      PHOENIXD_BASE_URL: ${{ secrets.PHOENIXD_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build with Maven
+        run: mvn -q verify

--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Clone the repository and run the Maven build:
 mvn clean install
 ```
 
-This will compile all modules and execute the unit tests. The tests expect a `phoenixd` instance running locally and some configuration values defined in `phoenixd-test/src/test/resources/app.properties`.
+This will compile all modules and execute the unit tests. The tests expect a `phoenixd` instance running locally and the following environment variables to be set:
 
+```
+PHOENIXD_USERNAME
+PHOENIXD_PASSWORD
+PHOENIXD_BASE_URL
+```
 
-Before running the tests, update the `test.pay_lnaddress` entry in that file so it targets a Lightning address that you control.
+Some test-specific values such as `test.pay_lnaddress` remain in `phoenixd-test/src/test/resources/app.properties`; update them as needed to target a Lightning address that you control.
 
 ## Testing
 Run the full test suite from the repository root:

--- a/phoenixd-base/src/main/java/xyz/tcheeric/phoenixd/common/rest/util/Configuration.java
+++ b/phoenixd-base/src/main/java/xyz/tcheeric/phoenixd/common/rest/util/Configuration.java
@@ -19,6 +19,23 @@ public class Configuration {
     private final @NonNull String prefix;
     private final PropertiesConfiguration properties;
 
+    private String envKey(@NonNull String key) {
+        return (prefix + "_" + key).toUpperCase().replace('.', '_');
+    }
+
+    private String envValue(@NonNull String key) {
+        String value = System.getenv(envKey(key));
+        return (value == null || value.isEmpty()) ? null : value;
+    }
+
+    private String resolve(@NonNull String key) {
+        String env = envValue(key);
+        if (env != null) {
+            return env;
+        }
+        return properties.getString(prefix + "." + key, null);
+    }
+
     @SneakyThrows
     public Configuration(@NonNull String prefix, @NonNull URL fileUrl) {
         this.prefix = prefix;
@@ -45,42 +62,51 @@ public class Configuration {
     }
 
     public String get(@NonNull String key) {
-        return properties.getString(prefix + "." + key, null);
+        return resolve(key);
     }
 
     public int getInt(@NonNull String key, int defaultValue) {
-        return properties.getInt(prefix + "." + key, defaultValue);
+        String value = resolve(key);
+        return value != null ? Integer.parseInt(value) : defaultValue;
     }
 
     public Long getLong(@NonNull String key) {
-        return properties.getLong(prefix + "." + key, Long.MIN_VALUE);
+        String value = resolve(key);
+        return value != null ? Long.valueOf(value) : Long.MIN_VALUE;
     }
 
     public Long getLong(@NonNull String key, Long defaultValue) {
-        return properties.getLong(prefix + "." + key, defaultValue);
+        String value = resolve(key);
+        return value != null ? Long.valueOf(value) : defaultValue;
     }
 
     public Double getDouble(@NonNull String key) {
-        return properties.getDouble(prefix + "." + key, Double.MIN_VALUE);
+        String value = resolve(key);
+        return value != null ? Double.valueOf(value) : Double.MIN_VALUE;
     }
 
     public Double getDouble(@NonNull String key, Double defaultValue) {
-        return properties.getDouble(prefix + "." + key, defaultValue);
+        String value = resolve(key);
+        return value != null ? Double.valueOf(value) : defaultValue;
     }
 
     public Integer getInt(@NonNull String key) {
-        return properties.getInt(prefix + "." + key, Integer.MIN_VALUE);
+        String value = resolve(key);
+        return value != null ? Integer.valueOf(value) : Integer.MIN_VALUE;
     }
 
     public boolean getBoolean(@NonNull String key) {
-        return properties.getBoolean(prefix + "." + key, false);
+        String value = resolve(key);
+        return value != null ? Boolean.parseBoolean(value) : false;
     }
 
     public String get(@NonNull String key, @NonNull String defaultValue) {
-        return properties.getString(prefix + "." + key, defaultValue);
+        String value = resolve(key);
+        return value != null ? value : defaultValue;
     }
 
     public boolean getBoolean(@NonNull String key, boolean defaultValue) {
-        return properties.getBoolean(prefix + "." + key, defaultValue);
+        String value = resolve(key);
+        return value != null ? Boolean.parseBoolean(value) : defaultValue;
     }
 }

--- a/phoenixd-rest/src/main/resources/app.properties
+++ b/phoenixd-rest/src/main/resources/app.properties
@@ -1,5 +1,5 @@
 phoenixd.username=
-phoenixd.password=49c6311a099407885c1b161f57c5c0ea4cb7cb2636a99488b870ffd8090a453a
-phoenixd.base_url=http://localhost:9740
+phoenixd.password=
+phoenixd.base_url=
 phoenixd.timeout=5000
 phoenixd.webhook_secret=

--- a/phoenixd-test/src/test/resources/app.properties
+++ b/phoenixd-test/src/test/resources/app.properties
@@ -1,6 +1,6 @@
 phoenixd.username=
-phoenixd.password=49c6311a099407885c1b161f57c5c0ea4cb7cb2636a99488b870ffd8090a453a
-phoenixd.base_url=http://localhost:9740
+phoenixd.password=
+phoenixd.base_url=
 phoenixd.timeout=5000
 phoenixd.webhook_secret=
 


### PR DESCRIPTION
## Summary
- read Phoenixd configuration from PHOENIXD_* environment variables
- remove in-repo credential values and document required env vars
- add CI workflow exposing secrets to tests

## Testing
- `mvn -q verify`
  - `Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts`


------
https://chatgpt.com/codex/tasks/task_b_6896a482d3648331924f7f69b1a9778d