### PR TITLE
Add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Build with Maven
+        run: mvn -q package
+
+      - name: Publish to GitHub Packages
+        run: mvn -q deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: phoenixd-rest/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/phoenixd-rest:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ This command executes unit and integration tests for all modules.
 ## Code coverage
 Running `mvn clean verify` generates a Jacoco coverage report. The aggregated HTML report is written to `target/site/jacoco-aggregate/index.html`.
 
+## Release
+
+Tag a commit with `v*` to trigger the release workflow. The workflow builds the JARs with `mvn -q package`, publishes them to GitHub Packages, and pushes a Docker image built from `phoenixd-rest/Dockerfile` to the GitHub Container Registry.
+
+
 ## Usage example
 ```java
 Configuration cfg = new Configuration("phoenixd");


### PR DESCRIPTION
## Summary
- add release GitHub Actions workflow for version tags
- document release process

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_6896a406016c8331b0139b361b42ba46