### PR TITLE
chore: streamline maven steps in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '21'
           cache: maven
       - name: Verify
-        run: mvn -q verify
+        run: mvn -B -q -ntp verify
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Build with Maven
-        run: mvn -q package
+        run: mvn -B -q -ntp verify
 
       - name: Publish to GitHub Packages
-        run: mvn -q deploy
+        run: mvn -B -q -ntp deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- use Maven batch mode and quiet flags in CI verify step
- streamline Maven build and deploy commands in release workflow

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*

------
https://chatgpt.com/codex/tasks/task_b_6896b384f28c8331a252e75544e492fd