### PR TITLE
Add permissions block to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add minimal `contents` read permissions for CI workflow
- add `contents` and `packages` write permissions for release workflow

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*
- `./bin/act --dryrun` *(fails: workflow is not valid. 'ci.yml': mapping key "steps" already defined)*
- `./bin/act --dryrun -W .github/workflows/release.yml` *(aborted: requires Docker image selection; Docker not available)*

------
https://chatgpt.com/codex/tasks/task_b_6896b395f0708331bcb930b78796eb6c