### PR TITLE
chore: run verify and deploy separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Build with Maven
-        run: mvn -q package
+        run: mvn -B -q verify
 
       - name: Publish to GitHub Packages
-        run: mvn -q deploy
+        run: mvn -B -q deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- verify the project with `mvn -B -q verify` during release
- deploy artifacts in a separate `mvn -B -q deploy` step

## Testing
- `mvn -q verify` *(failed: Coverage checks have not been met on project phoenixd-base)*

------
https://chatgpt.com/codex/tasks/task_b_6896b38b4e7883319704fd1279dc4cf3