### PR TITLE
Remove unnecessary spring-context dependency from model module

### DIFF
--- a/phoenixd-model/pom.xml
+++ b/phoenixd-model/pom.xml
@@ -28,11 +28,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>6.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary
- remove `org.springframework:spring-context` dependency from `phoenixd-model`

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met in `phoenixd-base`)*
```
[ERROR] Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.12:check (coverage-check) on project phoenixd-base: Coverage checks have not been met. See log for details. -> [Help 1]
```


------
https://chatgpt.com/codex/tasks/task_b_6896b5f3f8c0833198b8a95046ab21f4