### PR TITLE
Encode invoice parameters and add encoding tests

### DIFF
--- a/phoenixd-model/pom.xml
+++ b/phoenixd-model/pom.xml
@@ -36,6 +36,16 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
@@ -31,6 +31,9 @@ public class CreateInvoiceParam implements Request.Param {
     }
 
     private static String encode(String value) {
+        if (value == null) {
+            return "";
+        }
         return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
@@ -22,7 +22,8 @@ public class CreateInvoiceParam implements Request.Param {
         StringBuilder sb = new StringBuilder();
         sb.append("description=").append(encode(description))
                 .append("&amountSat=").append(encode(String.valueOf(amountSat)))
-                .append("&expirySeconds=").append(encode(String.valueOf(expirySeconds)))
+                .append("&amountSat=").append(amountSat == null ? "" : amountSat)
+                .append("&expirySeconds=").append(expirySeconds == null ? "" : expirySeconds)
                 .append("&externalId=").append(encode(externalId));
         if (webhookUrl != null) {
             sb.append("&webhookUrl=").append(encode(webhookUrl.toString()));

--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import xyz.tcheeric.phoenixd.common.rest.Request;
 
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Data
 public class CreateInvoiceParam implements Request.Param {
@@ -18,13 +20,17 @@ public class CreateInvoiceParam implements Request.Param {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("description=").append(description)
-                .append("&amountSat=").append(amountSat)
-                .append("&expirySeconds=").append(expirySeconds)
-                .append("&externalId=").append(externalId);
+        sb.append("description=").append(encode(description))
+                .append("&amountSat=").append(encode(String.valueOf(amountSat)))
+                .append("&expirySeconds=").append(encode(String.valueOf(expirySeconds)))
+                .append("&externalId=").append(encode(externalId));
         if (webhookUrl != null) {
-            sb.append("&webhookUrl=").append(webhookUrl);
+            sb.append("&webhookUrl=").append(encode(webhookUrl.toString()));
         }
         return sb.toString();
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParamTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParamTest.java
@@ -1,0 +1,28 @@
+package xyz.tcheeric.phoenixd.model.param;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateInvoiceParamTest {
+
+    @Test
+    void toStringEncodesValues() throws MalformedURLException {
+        CreateInvoiceParam param = new CreateInvoiceParam();
+        param.setDescription("hello world");
+        param.setAmountSat(1);
+        param.setExpirySeconds(2);
+        param.setExternalId("id=1&other");
+        param.setWebhookUrl(new URL("https://example.com/hook?foo=bar&baz=qux"));
+
+        String result = param.toString();
+
+        assertThat(result)
+                .contains("description=hello+world")
+                .contains("externalId=id%3D1%26other")
+                .contains("webhookUrl=https%3A%2F%2Fexample.com%2Fhook%3Ffoo%3Dbar%26baz%3Dqux");
+    }
+}


### PR DESCRIPTION
## Summary
- URL-encode all CreateInvoiceParam fields when building query strings
- Add unit test exercising encoding of spaces and special symbols
- Include JUnit and AssertJ test dependencies for phoenixd-model module

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*
- `mvn -pl phoenixd-model -am test`


------
https://chatgpt.com/codex/tasks/task_b_6896b5f9753483319f06e70bca52b109