### PR TITLE
Replace asynchronous HTTP request with synchronous send

### DIFF
--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -20,7 +20,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -117,10 +116,9 @@ public abstract class AbstractOperation implements Operation {
     @SneakyThrows
     @Override
     public Operation execute() {
-        CompletableFuture<HttpResponse<String>> response = HttpClient.newBuilder()
+        HttpResponse<String> httpResp = HttpClient.newBuilder()
                 .build()
-                .sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString());
-        HttpResponse<String> httpResp = response.get();
+                .send(httpRequest, HttpResponse.BodyHandlers.ofString());
         this.responseBody = httpResp.body();
         var statusCode = httpResp.statusCode();
         if (statusCode < 200 || statusCode >= 300) {

--- a/phoenixd-rest/src/test/java/xyz/tcheeric/phoenixd/operation/AbstractOperationTest.java
+++ b/phoenixd-rest/src/test/java/xyz/tcheeric/phoenixd/operation/AbstractOperationTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AbstractOperationTest {
 
     @Test
-    void executeMakesSingleNetworkCall() throws Exception {
+    void executeWithHttpClientSendMakesSingleNetworkCall() throws Exception {
         MockWebServer server = new MockWebServer();
         server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
         server.start();
@@ -26,6 +26,7 @@ public class AbstractOperationTest {
             operation.execute();
 
             assertThat(server.getRequestCount()).isEqualTo(1);
+            assertThat(server.takeRequest().getMethod()).isEqualTo("GET");
             assertThat(operation.getResponseBody()).isEqualTo("ok");
         } finally {
             server.shutdown();


### PR DESCRIPTION
## Summary
- Use synchronous `HttpClient.send` for executing operations
- Test synchronous call using `MockWebServer` to ensure a single network request

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*


------
https://chatgpt.com/codex/tasks/task_b_6896b600dcf4833180a8b7c60d48005e