### PR TITLE
test: expand request coverage

### DIFF
--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
@@ -78,7 +78,7 @@ public class CreateBolt11InvoiceRequestTest {
 
     @Test
     public void testErrorHandling() throws Exception {
-        HttpServer errorServer = HttpServer.create(new InetSocketAddress(9750), 0);
+        HttpServer errorServer = HttpServer.create(new InetSocketAddress(ERROR_SERVER_PORT), 0);
         errorServer.createContext("/createinvoice", exchange -> {
             byte[] bytes = "error".getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(500, bytes.length);

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
@@ -88,7 +88,7 @@ public class CreateBolt11InvoiceRequestTest {
         });
         errorServer.start();
         try {
-            TestUtils.setBaseUrl("http://localhost:9750");
+            TestUtils.setBaseUrl("http://localhost:" + ERROR_PORT);
             CreateBolt11InvoiceRequest request = new CreateBolt11InvoiceRequest(new CreateInvoiceParam());
             assertThrows(IOException.class, request::getResponse);
         } finally {

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/CreateBolt11InvoiceRequestTest.java
@@ -2,16 +2,22 @@ package xyz.tcheeric.phoenixd.request.impl.rest.test;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import xyz.tcheeric.phoenixd.test.LocalTestServerExtension;
 import xyz.tcheeric.phoenixd.model.param.CreateInvoiceParam;
 import xyz.tcheeric.phoenixd.model.response.CreateInvoiceResponse;
 import xyz.tcheeric.phoenixd.request.impl.rest.CreateBolt11InvoiceRequest;
+import xyz.tcheeric.phoenixd.test.LocalTestServerExtension;
+import xyz.tcheeric.phoenixd.test.TestUtils;
 
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(LocalTestServerExtension.class)
 public class CreateBolt11InvoiceRequestTest {
@@ -57,5 +63,37 @@ public class CreateBolt11InvoiceRequestTest {
         assertNotNull(response.getSerialized());
         assertNotNull(response.getPaymentHash());
         log.log(Level.ALL, "Invoice: {0}", response.getSerialized());
+    }
+
+    @Test
+    public void testUriAndHeaders() {
+        // Arrange
+        CreateBolt11InvoiceRequest request = new CreateBolt11InvoiceRequest(new CreateInvoiceParam());
+
+        // Assert
+        assertEquals("http://localhost:9740/createinvoice", request.getOperation().getHttpRequest().uri().toString());
+        assertEquals("Basic Og==", request.getOperation().getHeader("Authorization"));
+        assertEquals("application/x-www-form-urlencoded", request.getOperation().getHeader("Content-Type"));
+    }
+
+    @Test
+    public void testErrorHandling() throws Exception {
+        HttpServer errorServer = HttpServer.create(new InetSocketAddress(9750), 0);
+        errorServer.createContext("/createinvoice", exchange -> {
+            byte[] bytes = "error".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        errorServer.start();
+        try {
+            TestUtils.setBaseUrl("http://localhost:9750");
+            CreateBolt11InvoiceRequest request = new CreateBolt11InvoiceRequest(new CreateInvoiceParam());
+            assertThrows(IOException.class, request::getResponse);
+        } finally {
+            errorServer.stop(0);
+            TestUtils.setBaseUrl("http://localhost:9740");
+        }
     }
 }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayLightningAddressTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayLightningAddressTest.java
@@ -8,8 +8,16 @@ import xyz.tcheeric.phoenixd.model.response.PayLightningAddressInvoiceResponse;
 import xyz.tcheeric.phoenixd.operation.impl.PostOperation;
 import xyz.tcheeric.phoenixd.request.impl.rest.PayLightningAddressRequest;
 import xyz.tcheeric.phoenixd.test.LocalTestServerExtension;
+import xyz.tcheeric.phoenixd.test.TestUtils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(LocalTestServerExtension.class)
 public class PayLightningAddressTest {
@@ -32,6 +40,44 @@ public class PayLightningAddressTest {
         assertEquals(PostOperation.class, payLightningAddressRequest.getOperation().getClass());
         assertEquals(payLightningAddressParam.toString(), payLightningAddressRequest.getOperation().getRequestData());
         assertEquals(10, response.getRecipientAmountSat());
+    }
+
+    @Test
+    public void testUriAndHeaders() {
+        PayLightningAddressParam param = new PayLightningAddressParam();
+        param.setAddress("398ja@strike.me");
+        param.setMessage("msg");
+        param.setAmountSat(10);
+        PayLightningAddressRequest request = new PayLightningAddressRequest(param);
+
+        assertEquals("http://localhost:9740/paylnaddress", request.getOperation().getHttpRequest().uri().toString());
+        assertEquals("Basic Og==", request.getOperation().getHeader("Authorization"));
+        assertEquals("application/x-www-form-urlencoded", request.getOperation().getHeader("Content-Type"));
+    }
+
+    @Test
+    public void testErrorHandling() throws Exception {
+        HttpServer errorServer = HttpServer.create(new InetSocketAddress(9751), 0);
+        errorServer.createContext("/paylnaddress", exchange -> {
+            byte[] bytes = "error".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        errorServer.start();
+        try {
+            TestUtils.setBaseUrl("http://localhost:9751");
+            PayLightningAddressParam param = new PayLightningAddressParam();
+            param.setAddress("398ja@strike.me");
+            param.setMessage("msg");
+            param.setAmountSat(10);
+            PayLightningAddressRequest request = new PayLightningAddressRequest(param);
+            assertThrows(IOException.class, request::getResponse);
+        } finally {
+            errorServer.stop(0);
+            TestUtils.setBaseUrl("http://localhost:9740");
+        }
     }
 
 }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayLightningAddressTest.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/request/impl/rest/test/PayLightningAddressTest.java
@@ -67,7 +67,7 @@ public class PayLightningAddressTest {
         });
         errorServer.start();
         try {
-            TestUtils.setBaseUrl("http://localhost:9751");
+            TestUtils.setBaseUrl("http://localhost:" + ERROR_SERVER_PORT);
             PayLightningAddressParam param = new PayLightningAddressParam();
             param.setAddress("398ja@strike.me");
             param.setMessage("msg");

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/LocalTestServerExtension.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/LocalTestServerExtension.java
@@ -4,12 +4,15 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import static xyz.tcheeric.phoenixd.test.TestUtils.setBaseUrl;
+
 public class LocalTestServerExtension implements BeforeAllCallback, AfterAllCallback {
     private static final LocalTestServer SERVER = new LocalTestServer();
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         SERVER.start();
+        setBaseUrl("http://localhost:9740");
     }
 
     @Override

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
@@ -1,0 +1,22 @@
+package xyz.tcheeric.phoenixd.test;
+
+import xyz.tcheeric.phoenixd.operation.AbstractOperation;
+
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+public final class TestUtils {
+    private TestUtils() {
+    }
+
+    public static void setBaseUrl(String baseUrl) {
+        try {
+            Field configField = AbstractOperation.class.getDeclaredField("CONFIG");
+            configField.setAccessible(true);
+            Properties props = (Properties) configField.get(null);
+            props.setProperty("phoenixd.base_url", baseUrl);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
@@ -21,7 +21,7 @@ public final class TestUtils {
             Field configField = AbstractOperation.class.getDeclaredField(CONFIG_FIELD_NAME);
             configField.setAccessible(true);
             Properties props = (Properties) configField.get(null);
-            props.setProperty("phoenixd.base_url", baseUrl);
+            props.setProperty(PHOENIXD_BASE_URL_KEY, baseUrl);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
@@ -11,7 +11,14 @@ public final class TestUtils {
 
     public static void setBaseUrl(String baseUrl) {
         try {
-            Field configField = AbstractOperation.class.getDeclaredField("CONFIG");
+    private static final String CONFIG_FIELD_NAME = "CONFIG";
+
+    private TestUtils() {
+    }
+
+    public static void setBaseUrl(String baseUrl) {
+        try {
+            Field configField = AbstractOperation.class.getDeclaredField(CONFIG_FIELD_NAME);
             configField.setAccessible(true);
             Properties props = (Properties) configField.get(null);
             props.setProperty("phoenixd.base_url", baseUrl);


### PR DESCRIPTION
## Summary
- provide `TestUtils.setBaseUrl` to programmatically set the REST base URL for tests
- extend request tests to verify URI construction, authorization/content-type headers, and error propagation

## Testing
- `mvn -q verify` *(fails: Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.12:check (coverage-check) on project phoenixd-base: Coverage checks have not been met)*


------
https://chatgpt.com/codex/tasks/task_b_6896b5e310b88331a139777c23d8cef8