### PR TITLE
Add tests for model param and response classes

### DIFF
--- a/phoenixd-model/pom.xml
+++ b/phoenixd-model/pom.xml
@@ -36,6 +36,16 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParamTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParamTest.java
@@ -1,0 +1,43 @@
+package xyz.tcheeric.phoenixd.model.param;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateInvoiceParamTest {
+
+    @Test
+    void settersGettersAndToStringWithWebhook() throws Exception {
+        CreateInvoiceParam param = new CreateInvoiceParam();
+        param.setDescription("desc");
+        param.setAmountSat(1);
+        param.setExpirySeconds(2);
+        param.setExternalId("id");
+        URL url = new URL("https://example.com");
+        param.setWebhookUrl(url);
+
+        assertThat(param.getDescription()).isEqualTo("desc");
+        assertThat(param.getAmountSat()).isEqualTo(1);
+        assertThat(param.getExpirySeconds()).isEqualTo(2);
+        assertThat(param.getExternalId()).isEqualTo("id");
+        assertThat(param.getWebhookUrl()).isEqualTo(url);
+
+        assertThat(param.toString()).isEqualTo(
+                "description=desc&amountSat=1&expirySeconds=2&externalId=id&webhookUrl=https://example.com");
+    }
+
+    @Test
+    void toStringWithoutWebhook() {
+        CreateInvoiceParam param = new CreateInvoiceParam();
+        param.setDescription("desc");
+        param.setAmountSat(1);
+        param.setExpirySeconds(2);
+        param.setExternalId("id");
+
+        assertThat(param.toString())
+                .isEqualTo("description=desc&amountSat=1&expirySeconds=2&externalId=id");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/DecodeInvoiceParamTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/DecodeInvoiceParamTest.java
@@ -1,0 +1,21 @@
+package xyz.tcheeric.phoenixd.model.param;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DecodeInvoiceParamTest {
+
+    @Test
+    void settersGettersAndToString() {
+        DecodeInvoiceParam param = new DecodeInvoiceParam();
+        param.setInvoice("invoice123");
+
+        assertThat(param.getInvoice()).isEqualTo("invoice123");
+        assertThat(param.toString()).isEqualTo("invoice=invoice123");
+
+        param.setInvoice(null);
+        assertThat(param.toString()).isEqualTo("invoice=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/PayBolt11InvoiceParamTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/PayBolt11InvoiceParamTest.java
@@ -1,0 +1,23 @@
+package xyz.tcheeric.phoenixd.model.param;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayBolt11InvoiceParamTest {
+
+    @Test
+    void settersGettersAndToString() {
+        PayBolt11InvoiceParam param = new PayBolt11InvoiceParam();
+        param.setAmountSat(50);
+        param.setInvoice("inv");
+
+        assertThat(param.getAmountSat()).isEqualTo(50);
+        assertThat(param.getInvoice()).isEqualTo("inv");
+        assertThat(param.toString()).isEqualTo("amountSat=50&invoice=inv");
+
+        param.setInvoice(null);
+        assertThat(param.toString()).isEqualTo("amountSat=50&invoice=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/PayLightningAddressParamTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/param/PayLightningAddressParamTest.java
@@ -1,0 +1,34 @@
+package xyz.tcheeric.phoenixd.model.param;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayLightningAddressParamTest {
+
+    @Test
+    void settersGettersAndToStringWithMessage() {
+        PayLightningAddressParam param = new PayLightningAddressParam();
+        param.setAmountSat(70);
+        param.setAddress("addr");
+        param.setMessage("hello");
+
+        assertThat(param.getAmountSat()).isEqualTo(70);
+        assertThat(param.getAddress()).isEqualTo("addr");
+        assertThat(param.getMessage()).isEqualTo("hello");
+        assertThat(param.toString()).isEqualTo("amountSat=70&address=addr&message=hello");
+    }
+
+    @Test
+    void toStringWithoutMessage() {
+        PayLightningAddressParam param = new PayLightningAddressParam();
+        param.setAmountSat(70);
+        param.setAddress("addr");
+
+        assertThat(param.toString()).isEqualTo("amountSat=70&address=addr");
+
+        param.setMessage("");
+        assertThat(param.toString()).isEqualTo("amountSat=70&address=addr");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/CreateInvoiceResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/CreateInvoiceResponseTest.java
@@ -1,0 +1,25 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateInvoiceResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        CreateInvoiceResponse response = new CreateInvoiceResponse();
+        response.setAmountSat(123);
+        response.setPaymentHash("hash");
+        response.setSerialized("serialized");
+
+        assertThat(response.getAmountSat()).isEqualTo(123);
+        assertThat(response.getPaymentHash()).isEqualTo("hash");
+        assertThat(response.getSerialized()).isEqualTo("serialized");
+        assertThat(response.toString()).contains("amountSat=123", "paymentHash=hash", "serialized=serialized");
+
+        response.setPaymentHash(null);
+        assertThat(response.toString()).contains("paymentHash=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/DecodeInvoiceResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/DecodeInvoiceResponseTest.java
@@ -1,0 +1,61 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DecodeInvoiceResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        DecodeInvoiceResponse response = new DecodeInvoiceResponse();
+        response.setAmount(1);
+        response.setDescription("desc");
+        response.setChain("chain");
+        response.setPaymentHash("hash");
+        response.setMinFinalCltvExpiryDelta(2);
+        response.setPaymentSecret("secret");
+        response.setPaymentMetadata(null);
+        response.setTimestampSeconds(123L);
+
+        DecodeInvoiceResponse.ExtraHop hop = new DecodeInvoiceResponse.ExtraHop();
+        hop.setNodeId("node");
+        hop.setShortChannelId("scid");
+        hop.setFeeBase(3);
+        hop.setFeeProportionalMillionths(4);
+        hop.setCltvExpiryDelta(5);
+        response.setExtraHops(List.of(List.of(hop)));
+
+        DecodeInvoiceResponse.Activated activated = new DecodeInvoiceResponse.Activated();
+        activated.setVar_onion_optin("v");
+        activated.setPayment_secret("ps");
+        activated.setBasic_mpp("bmpp");
+        activated.setOption_payment_metadata("opm");
+        activated.setTrampoline_payment_experimental("tpe");
+
+        DecodeInvoiceResponse.Features features = new DecodeInvoiceResponse.Features();
+        features.setActivated(activated);
+        features.setUnknown(List.of("x"));
+        response.setFeatures(features);
+
+        assertThat(response.getAmount()).isEqualTo(1);
+        assertThat(response.getDescription()).isEqualTo("desc");
+        assertThat(response.getChain()).isEqualTo("chain");
+        assertThat(response.getPaymentHash()).isEqualTo("hash");
+        assertThat(response.getMinFinalCltvExpiryDelta()).isEqualTo(2);
+        assertThat(response.getPaymentSecret()).isEqualTo("secret");
+        assertThat(response.getPaymentMetadata()).isNull();
+        assertThat(response.getExtraHops()).hasSize(1);
+        assertThat(response.getFeatures().getActivated().getBasic_mpp()).isEqualTo("bmpp");
+        assertThat(response.getFeatures().getUnknown()).contains("x");
+
+        assertThat(hop.toString()).contains("nodeId=node", "feeBase=3");
+        assertThat(activated.toString()).contains("var_onion_optin=v", "trampoline_payment_experimental=tpe");
+        assertThat(features.toString()).contains("unknown=[x]");
+
+        assertThat(response.toString()).contains("amount=1", "description=desc", "chain=chain", "paymentMetadata=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/GetLightningAddressResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/GetLightningAddressResponseTest.java
@@ -1,0 +1,22 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GetLightningAddressResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        GetLightningAddressResponse response = new GetLightningAddressResponse();
+        response.setLightningAddress("user@host");
+
+        assertThat(response.getLightningAddress()).isEqualTo("user@host");
+        assertThat(response.toString()).contains("lightningAddress=user@host");
+
+        GetLightningAddressResponse response2 = new GetLightningAddressResponse(null);
+        assertThat(response2.getLightningAddress()).isNull();
+        assertThat(response2.toString()).contains("lightningAddress=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayBolt11InvoiceInvoiceResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayBolt11InvoiceInvoiceResponseTest.java
@@ -1,0 +1,31 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayBolt11InvoiceInvoiceResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        PayBolt11InvoiceInvoiceResponse response = new PayBolt11InvoiceInvoiceResponse();
+        response.setRecipientAmountSat(20);
+        response.setRoutingFeeSat(2);
+        response.setPaymentId("pid");
+        response.setPaymentHash("hash");
+        response.setPaymentPreimage("preimage");
+        response.setReason(null);
+
+        assertThat(response.getPaymentPreimage()).isEqualTo("preimage");
+        assertThat(response.getReason()).isNull();
+
+        assertThat(response.toString()).contains(
+                "recipientAmountSat=20",
+                "routingFeeSat=2",
+                "paymentId=pid",
+                "paymentHash=hash",
+                "paymentPreimage=preimage",
+                "reason=null");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayInvoiceResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayInvoiceResponseTest.java
@@ -1,0 +1,35 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayInvoiceResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        PayInvoiceResponse response = new PayInvoiceResponse();
+        response.setRecipientAmountSat(10);
+        response.setRoutingFeeSat(1);
+        response.setPaymentId("pid");
+        response.setPaymentHash("hash");
+        response.setPaymentPreimage(null);
+        response.setReason("reason");
+
+        assertThat(response.getRecipientAmountSat()).isEqualTo(10);
+        assertThat(response.getRoutingFeeSat()).isEqualTo(1);
+        assertThat(response.getPaymentId()).isEqualTo("pid");
+        assertThat(response.getPaymentHash()).isEqualTo("hash");
+        assertThat(response.getPaymentPreimage()).isNull();
+        assertThat(response.getReason()).isEqualTo("reason");
+
+        assertThat(response.toString()).contains(
+                "recipientAmountSat=10",
+                "routingFeeSat=1",
+                "paymentId=pid",
+                "paymentHash=hash",
+                "paymentPreimage=null",
+                "reason=reason");
+    }
+}
+

--- a/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayLightningAddressInvoiceResponseTest.java
+++ b/phoenixd-model/src/test/java/xyz/tcheeric/phoenixd/model/response/PayLightningAddressInvoiceResponseTest.java
@@ -1,0 +1,35 @@
+package xyz.tcheeric.phoenixd.model.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayLightningAddressInvoiceResponseTest {
+
+    @Test
+    void settersGettersAndToString() {
+        PayLightningAddressInvoiceResponse response = new PayLightningAddressInvoiceResponse();
+        response.setRecipientAmountSat(30);
+        response.setRoutingFeeSat(3);
+        response.setPaymentId("pid");
+        response.setPaymentHash("hash");
+        response.setPaymentPreimage(null);
+        response.setReason("reason");
+
+        assertThat(response.getRecipientAmountSat()).isEqualTo(30);
+        assertThat(response.getRoutingFeeSat()).isEqualTo(3);
+        assertThat(response.getPaymentId()).isEqualTo("pid");
+        assertThat(response.getPaymentHash()).isEqualTo("hash");
+        assertThat(response.getPaymentPreimage()).isNull();
+        assertThat(response.getReason()).isEqualTo("reason");
+
+        assertThat(response.toString()).contains(
+                "recipientAmountSat=30",
+                "routingFeeSat=3",
+                "paymentId=pid",
+                "paymentHash=hash",
+                "paymentPreimage=null",
+                "reason=reason");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add JUnit tests for all model param classes, covering getters, setters and toString behaviors including null cases
- add tests for response classes and nested structures to ensure getters, setters and toString work correctly
- include JUnit and AssertJ test dependencies in phoenixd-model module

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met in phoenixd-base)*

------
https://chatgpt.com/codex/tasks/task_b_6896b5e02c3483318041f9d4bc2c379a