### PR TITLE
ci: expand branch triggers and report coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
+    branches: [ main, develop ]
 
 jobs:
   build:
@@ -15,7 +16,7 @@ jobs:
       PHOENIXD_PASSWORD: ${{ secrets.PHOENIXD_PASSWORD }}
       PHOENIXD_BASE_URL: ${{ secrets.PHOENIXD_BASE_URL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -25,7 +26,26 @@ jobs:
       - name: Verify
         run: mvn -B -q -ntp verify
 
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts
+          path: |
+            **/target/surefire-reports
+            **/target/jacoco.exec
+
       - name: Upload coverage report
+        uses: codecov/codecov-action@v5
+        with:
+          files: "**/target/site/jacoco/jacoco.xml"
+
+      - name: Publish test results
+        uses: codecov/test-results-action@v1
+        with:
+          files: "**/target/surefire-reports/*.xml"
+
+      - name: Upload jacoco aggregate
         if: always()
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- run CI on both `main` and `develop`
- upgrade to `actions/checkout@v5`
- upload surefire reports and JaCoCo exec, report coverage & test results to Codecov

## Testing
- `mvn -q verify` *(fails: CreateInvoiceParamTest.settersGettersAndToStringWithWebhook, CreateInvoiceParamTest.toStringWithoutWebhook, PayBolt11InvoiceInvoiceResponseTest.settersGettersAndToString, PayLightningAddressInvoiceResponseTest.settersGettersAndToString)*

------
https://chatgpt.com/codex/tasks/task_b_68a60a3bfdd08331b38e39efbe9480a9