### PR TITLE
Add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+# Disable GitHub's default CodeQL setup in the repository settings to avoid
+# "advanced configuration" errors when using this workflow.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: 'java'
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add CodeQL analysis workflow for push/pull_request on main and develop

## Testing
- `mvn -q verify` *(fails: Tests run: 13, Failures: 4, Errors: 0)*
```
[ERROR] Tests run: 13, Failures: 4, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project phoenixd-model: There are test failures.
```

## Network Access
- Accessed GitHub to reference workflow configuration; no blocked domains encountered.


------
https://chatgpt.com/codex/tasks/task_b_68a60a3d87e4833198fe31176a6e1bdb