### PR TITLE
Add issue labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+bug:
+  - '(?i)\bbug\b'
+feature:
+  - '(?i)\bfeature\b'
+question:
+  - '(?i)\bquestion\b'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,19 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3
+        with:
+          configuration-path: .github/labeler.yml
+          include-title: 1
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- add labeler configuration to tag issues mentioning bug, feature or question
- introduce workflow using github/issue-labeler@v3 with issues write permission

## Testing
- `mvn -q verify`
```
[ERROR] Tests run: 13, Failures: 4, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project phoenixd-model: There are test failures.
```


------
https://chatgpt.com/codex/tasks/task_b_68a60a492838833197a241144271e855