### PR TITLE
docs: enforce PR template usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,4 @@
 - Include any limitations or known issues in the description.
 - Add a "Network Access" section summarizing blocked domains if network requests were denied.
 - Ensure all new features, modules, or dependencies are properly documented in the `README.md` file.
+- Always follow the repository's PR submission guidelines and use the PR template located at `.github/pull_request_template.md`.


### PR DESCRIPTION
## Why now?
AGENTS.md lacked explicit instruction to follow the PR template, leading to inconsistent submissions.
Related issue: #0

## What changed?
- Added guidance to AGENTS.md to always follow PR submission guidelines and use the repository's PR template.

## BREAKING
None.

## Review focus
Ensure the new AGENTS.md instructions are clear and capture repository expectations.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

### Testing
`mvn -q verify`

```
[ERROR] Tests run: 13, Failures: 4, Errors: 0, Skipped: 0
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project phoenixd-model: There are test failures.
[ERROR] Please refer to /workspace/phoenixd-java/phoenixd-model/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :phoenixd-model
```

### Network Access
No external network requests were made.


------
https://chatgpt.com/codex/tasks/task_b_68a6504329cc8331b794a6ffeea0d6cf