### PR TITLE
Include super fields in invoice responses

### DIFF
--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/param/CreateInvoiceParam.java
@@ -21,12 +21,16 @@ public class CreateInvoiceParam implements Request.Param {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("description=").append(encode(description))
-                .append("&amountSat=").append(encode(String.valueOf(amountSat)))
                 .append("&amountSat=").append(amountSat == null ? "" : amountSat)
                 .append("&expirySeconds=").append(expirySeconds == null ? "" : expirySeconds)
                 .append("&externalId=").append(encode(externalId));
         if (webhookUrl != null) {
-            sb.append("&webhookUrl=").append(encode(webhookUrl.toString()));
+            String urlString = webhookUrl.toString();
+            if (urlString.contains("?")) {
+                sb.append("&webhookUrl=").append(encode(urlString));
+            } else {
+                sb.append("&webhookUrl=").append(urlString);
+            }
         }
         return sb.toString();
     }

--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/response/PayBolt11InvoiceInvoiceResponse.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/response/PayBolt11InvoiceInvoiceResponse.java
@@ -3,9 +3,11 @@ package xyz.tcheeric.phoenixd.model.response;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
+@ToString(callSuper = true)
 public class PayBolt11InvoiceInvoiceResponse extends PayInvoiceResponse {
 }

--- a/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/response/PayLightningAddressInvoiceResponse.java
+++ b/phoenixd-model/src/main/java/xyz/tcheeric/phoenixd/model/response/PayLightningAddressInvoiceResponse.java
@@ -3,9 +3,11 @@ package xyz.tcheeric.phoenixd.model.response;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
+@ToString(callSuper = true)
 public class PayLightningAddressInvoiceResponse extends PayInvoiceResponse {
 }

--- a/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
+++ b/phoenixd-rest/src/main/java/xyz/tcheeric/phoenixd/operation/AbstractOperation.java
@@ -175,10 +175,14 @@ public abstract class AbstractOperation implements Operation {
         Field[] fields = param.getClass().getDeclaredFields();
         for (Field field : fields) {
             field.setAccessible(true);
-            Object value = field.get(param);
-            if (value != null) {
-                String placeholder = "{" + field.getName() + "}";
-                path = path.replace(placeholder, value.toString());
+            try {
+                Object value = field.get(param);
+                if (value != null) {
+                    String placeholder = "{" + field.getName() + "}";
+                    path = path.replace(placeholder, value.toString());
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
         }
         return path;

--- a/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
+++ b/phoenixd-test/src/test/java/xyz/tcheeric/phoenixd/test/TestUtils.java
@@ -6,12 +6,8 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 public final class TestUtils {
-    private TestUtils() {
-    }
-
-    public static void setBaseUrl(String baseUrl) {
-        try {
     private static final String CONFIG_FIELD_NAME = "CONFIG";
+    private static final String PHOENIXD_BASE_URL_KEY = "phoenixd.base_url";
 
     private TestUtils() {
     }


### PR DESCRIPTION
## Summary
- ensure `PayLightningAddressInvoiceResponse` and `PayBolt11InvoiceInvoiceResponse` include parent fields in `toString`
- fix `CreateInvoiceParam` builder to avoid duplicate parameters and encode webhook URLs only when needed
- handle `IllegalAccessException` in `AbstractOperation.replacePathVariables`
- restore `TestUtils` utility for test configuration

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*
- `mvn -q -Djacoco.skip=true verify` *(fails: cannot find symbol `getHttpRequest`, `ERROR_SERVER_PORT`, `ERROR_PORT` in phoenixd-test)*

------
https://chatgpt.com/codex/tasks/task_b_68a67e73d2848331a9256765b51b5a16