### PR TITLE
build: publish Docker image with Jib during deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Artifacts are published to a Reposilite server. Add the repository to your Maven
 - A running instance of `phoenixd`
 - A valid Lightning address (for test runs)
 
+## Docker
+Build and publish the `phoenixd-rest` container image with the Jib Maven plugin:
+
+```bash
+./mvnw deploy -pl phoenixd-rest -am
+```
+
+This pushes `docker.398ja.xyz/phoenixd-rest` to the registry. See [Docker](docs/how-to/docker.md) for details.
+
 ## Documentation
 - Reference: [phoenixd REST API](https://phoenix.acinq.co/server/api)
 - How-to guides:

--- a/docs/how-to/docker.md
+++ b/docs/how-to/docker.md
@@ -1,11 +1,20 @@
 # Docker
 
-Build and run the `phoenixd-rest` module in a container after packaging the project:
+The `phoenixd-rest` module can be containerized and published to `docker.398ja.xyz`
+using the [Jib Maven plugin](https://github.com/GoogleContainerTools/jib).
+
+Build and push the image during the Maven `deploy` phase:
 
 ```bash
-mvn -q -pl phoenixd-rest -am package
-docker build -t phoenixd-rest ./phoenixd-rest
-docker run -p 9740:9740 phoenixd-rest
+./mvnw deploy -pl phoenixd-rest -am
+```
+
+Jib will publish `docker.398ja.xyz/phoenixd-rest:<version>`.
+
+To run the pushed image locally:
+
+```bash
+docker run -p 9740:9740 docker.398ja.xyz/phoenixd-rest:<version>
 ```
 
 The image uses Java 21 and exposes port `9740`.

--- a/phoenixd-rest/pom.xml
+++ b/phoenixd-rest/pom.xml
@@ -57,6 +57,42 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <from>
+                        <image>gcr.io/distroless/java21</image>
+                    </from>
+                    <to>
+                        <image>docker.398ja.xyz/phoenixd-rest</image>
+                        <tags>
+                            <tag>${project.version}</tag>
+                        </tags>
+                    </to>
+                    <containerizingMode>packaged</containerizingMode>
+                    <container>
+                        <entrypoint>
+                            <shell>java -jar /app.jar</shell>
+                        </entrypoint>
+                    </container>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>jib-build</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <distributionManagement>
         <repository>
             <id>reposilite-releases</id>


### PR DESCRIPTION
## Summary
- enable Jib to build/push phoenixd-rest images during Maven deploy
- document `./mvnw deploy` workflow for container publishing

## Testing
- `mvn -q verify`
- `mvn verify -e`
- `mvn -pl phoenixd-rest -am deploy -Dmaven.deploy.skip=true -DskipTests`

## Network Access
- `docker.398ja.xyz` (registry unreachable)


------
https://chatgpt.com/codex/tasks/task_b_68ab67eed62c833184ef5de8c1972cba