### PR TITLE
build: tag Docker images with latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ Artifacts are published to a Reposilite server. Add the repository to your Maven
 - A valid Lightning address (for test runs)
 
 ## Docker
-Build and publish the `phoenixd-rest` container image with the Jib Maven plugin:
+Build and publish the `phoenixd-rest` and `phoenixd-mock` container images with the Jib Maven plugin:
 
 ```bash
 ./mvnw deploy -pl phoenixd-rest -am
+./mvnw deploy -pl phoenixd-mock -am
 ```
 
-This pushes `docker.398ja.xyz/phoenixd-rest` to the registry. See [Docker](docs/how-to/docker.md) for details.
+Images are uploaded to `docker.398ja.xyz/phoenixd-rest` and `docker.398ja.xyz/phoenixd-mock` and tagged with both the project
+version and `latest`, allowing consumers to pull the most recent build without specifying a version. See
+[Docker](docs/how-to/docker.md) for details.
 
 ## Documentation
 - Reference: [phoenixd REST API](https://phoenix.acinq.co/server/api)

--- a/phoenixd-mock/pom.xml
+++ b/phoenixd-mock/pom.xml
@@ -71,6 +71,7 @@
                         <image>docker.398ja.xyz/phoenixd-mock</image>
                         <tags>
                             <tag>${project.version}</tag>
+                            <tag>latest</tag>
                         </tags>
                     </to>
                     <containerizingMode>packaged</containerizingMode>

--- a/phoenixd-rest/pom.xml
+++ b/phoenixd-rest/pom.xml
@@ -71,6 +71,7 @@
                         <image>docker.398ja.xyz/phoenixd-rest</image>
                         <tags>
                             <tag>${project.version}</tag>
+                            <tag>latest</tag>
                         </tags>
                     </to>
                     <containerizingMode>packaged</containerizingMode>


### PR DESCRIPTION
## Why now?
Enable consumers to pull the most recent `phoenixd` builds without specifying a version.

## What changed?
- Tag Jib images for `phoenixd-rest` and `phoenixd-mock` with project version and `latest` tags【F:phoenixd-rest/pom.xml†L70-L75】【F:phoenixd-mock/pom.xml†L70-L75】
- Document published Docker images and tags in README【F:README.md†L30-L39】

## BREAKING
- None

## Review focus
- Ensure Jib configuration pushes both tags to the registry and documentation is accurate.

## Testing
- `mvn -q verify` *(fails: IllegalArgumentException: URI with undefined scheme)*【d1e38f†L1-L12】【0d7f07†L1-L9】

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object**
- [ ] Description links the issue and answers "why now?"
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68abb2bc1608833190c0d14ba505dd72